### PR TITLE
fix: change broken link to TabStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Caso você queira adicionar algum projeto, leia as instruções de acordo com o 
 ### Sites
 | Nome | Descrição | Repositório | Link |
 |:----:|-----------|-------------|------|
-| **TabStats** | Obtenha informações de usuários do TabNews com o TabStats. | [gabrielsozinho/TabStats](https://github.com/gabrielsozinho/TabStats/) | https://tabstats.ga |
+| **TabStats** | Obtenha informações de usuários do TabNews com o TabStats. | [gabrielsozinho/TabStats](https://github.com/gabrielsozinho/TabStats/) | [https://tabstats.netlify.app](https://tabstats.netlify.app) |
 
 
 <div id="mobile"/>


### PR DESCRIPTION
O antigo link (tabstats.ga) parou de funcionar devido às falhas no Freenom. Então, agora apenas o link direto para a Netlify funciona e por isso a alteração no README. 